### PR TITLE
Use constraint-layout 1.0.2

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,6 @@ dependencies {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
     compile 'com.android.support:appcompat-v7:25.0.1'
-    compile 'com.android.support.constraint:constraint-layout:1.0.0-beta3'
+    compile 'com.android.support.constraint:constraint-layout:1.0.2'
     testCompile 'junit:junit:4.12'
 }


### PR DESCRIPTION
Hello,

We had to patch your app before building it on F-Droid because constraint-layout 1.0.0-beta3 is not available on jcenter.

This patch uses 1.0.2 which can be downloaded with Gradle.